### PR TITLE
Handle the uninstalled event on detroy, not the disabled event.

### DIFF
--- a/src/main/java/minhhai2209/jirapluginconverter/plugin/lifecycle/PluginLifeCycleEventListener.java
+++ b/src/main/java/minhhai2209/jirapluginconverter/plugin/lifecycle/PluginLifeCycleEventListener.java
@@ -184,6 +184,6 @@ public class PluginLifeCycleEventListener implements DisposableBean {
 
   @Override
   public void destroy() throws Exception {
-    handle(EventType.disabled, null);
+    handle(EventType.uninstalled, null);
   }
 }


### PR DESCRIPTION
On uninstall, the plugin was being disabled via `destroy` before it can finish resulting in a "service proxy has been destroyed" exception. Changing `destroy` to handle the `uninstalled` event ensures the uninstallation code finishes before the proxy is destroyed.

In my testing, I have not found any practical reason not to do this or any situation in which it produces undesired results.