### PR TITLE
Set the sub claim for jwt

### DIFF
--- a/src/main/java/minhhai2209/jirapluginconverter/plugin/jwt/JwtComposer.java
+++ b/src/main/java/minhhai2209/jirapluginconverter/plugin/jwt/JwtComposer.java
@@ -33,6 +33,7 @@ public class JwtComposer {
               .expirationTime(expiresAt)
               .issuer(key)
               .claim("context", context);
+              .subject(context.getUser().getUserKey());
       Map<String, List<String>> parameters = JwtHelper.getParameters(pairs);
       Map<String, String[]> parameterMap = JwtHelper.getParameterMap(parameters);
       CanonicalHttpUriRequest canonicalHttpUrlRequest = new CanonicalHttpUriRequest(method, apiPath, null, parameterMap);


### PR DESCRIPTION
atlassian-connect-express determines the current user's id via the `sub`
claim.

https://bitbucket.org/atlassian/atlassian-connect-express/src/90eaa959ecd6783dbf0f093dec27218a6cb7c3c4/lib/middleware/authentication.js?at=master&fileviewer=file-view-default#authentication.js-150

This ensures the claim is present inside the jwt prior to
submitting requests to the remote server: