### PR TITLE
Set default iframe height

### DIFF
--- a/src/main/java/minhhai2209/jirapluginconverter/plugin/jwt/JwtComposer.java
+++ b/src/main/java/minhhai2209/jirapluginconverter/plugin/jwt/JwtComposer.java
@@ -33,6 +33,7 @@ public class JwtComposer {
               .expirationTime(expiresAt)
               .issuer(key)
               .claim("context", context);
+              .subject(context.getUser().getUserKey());
       Map<String, List<String>> parameters = JwtHelper.getParameters(pairs);
       Map<String, String[]> parameterMap = JwtHelper.getParameterMap(parameters);
       CanonicalHttpUriRequest canonicalHttpUrlRequest = new CanonicalHttpUriRequest(method, apiPath, null, parameterMap);

--- a/src/main/java/minhhai2209/jirapluginconverter/plugin/jwt/JwtComposer.java
+++ b/src/main/java/minhhai2209/jirapluginconverter/plugin/jwt/JwtComposer.java
@@ -32,7 +32,7 @@ public class JwtComposer {
               .issuedAt(issuedAt)
               .expirationTime(expiresAt)
               .issuer(key)
-              .claim("context", context);
+              .claim("context", context)
               .subject(context.getUser().getUserKey());
       Map<String, List<String>> parameters = JwtHelper.getParameters(pairs);
       Map<String, String[]> parameterMap = JwtHelper.getParameterMap(parameters);

--- a/src/main/java/minhhai2209/jirapluginconverter/plugin/jwt/JwtComposer.java
+++ b/src/main/java/minhhai2209/jirapluginconverter/plugin/jwt/JwtComposer.java
@@ -32,8 +32,7 @@ public class JwtComposer {
               .issuedAt(issuedAt)
               .expirationTime(expiresAt)
               .issuer(key)
-              .claim("context", context)
-              .subject(context.getUser().getUserKey());
+              .claim("context", context);
       Map<String, List<String>> parameters = JwtHelper.getParameters(pairs);
       Map<String, String[]> parameterMap = JwtHelper.getParameterMap(parameters);
       CanonicalHttpUriRequest canonicalHttpUrlRequest = new CanonicalHttpUriRequest(method, apiPath, null, parameterMap);

--- a/src/main/java/minhhai2209/jirapluginconverter/plugin/render/WebPanelRenderer.java
+++ b/src/main/java/minhhai2209/jirapluginconverter/plugin/render/WebPanelRenderer.java
@@ -77,7 +77,7 @@ public class WebPanelRenderer implements com.atlassian.plugin.web.renderer.WebPa
       String w = "";
       // make sure the iframe is at least visible by default given a raw html fragment
       // this can be overriden within the head/body of the iframe via a style block or external css file
-      String h = "500px";
+      String h = "250px";
       String productCtx = JsonUtils.toJson(productContext);
       String timezone = timeZone.getID();
       String loc = LocaleUtils.getLocale(localeResolver);

--- a/src/main/java/minhhai2209/jirapluginconverter/plugin/render/WebPanelRenderer.java
+++ b/src/main/java/minhhai2209/jirapluginconverter/plugin/render/WebPanelRenderer.java
@@ -75,7 +75,9 @@ public class WebPanelRenderer implements com.atlassian.plugin.web.renderer.WebPa
       String simpleDlg = dlg;
       String general = "";
       String w = "";
-      String h = "";
+      // make sure the iframe is at least visible by default given a raw html fragment
+      // this can be overriden within the head/body of the iframe via a style block or external css file
+      String h = "500px";
       String productCtx = JsonUtils.toJson(productContext);
       String timezone = timeZone.getID();
       String loc = LocaleUtils.getLocale(localeResolver);


### PR DESCRIPTION
With the default iframe height being set to an empty string, it is not visible when text-only html responses are generated from remote server:

```js
// node.js express app handler
router.get('/iframe-endpoint', (req, res) => {
  res.send('text only response with text/html content type')
})
```

This ensures that the iframe is at least visible by default but still allows a client developer to override via css.